### PR TITLE
Bump versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '0.15.5' apply false
+    id 'io.spine.tools.gradle.bootstrap' version '0.15.6' apply false
     id 'net.ltgt.errorprone' version '0.8.1' apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
         implementation deps.build.guava
         implementation deps.build.checkerAnnotations
 
-        runtime deps.grpc.grpcNetty
+        runtimeOnly deps.grpc.grpcNetty
 
         testImplementation group: 'io.spine', name: 'spine-testutil-server', version: spineVersion
         testRuntimeOnly deps.test.junit5Runner

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ subprojects {
         implementation deps.build.guava
         implementation deps.build.checkerAnnotations
 
+        runtime deps.grpc.grpcNetty
+
         testImplementation group: 'io.spine', name: 'spine-testutil-server', version: spineVersion
         testRuntimeOnly deps.test.junit5Runner
     }

--- a/build.gradle
+++ b/build.gradle
@@ -48,13 +48,28 @@ subprojects {
         testRuntimeOnly deps.test.junit5Runner
     }
 
-    compileJava {
-        options.encoding = 'UTF-8'
-        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-    }
+    tasks.withType(JavaCompile) {
 
-    compileTestJava {
+        // Explicitly states the encoding of the source and test source files, ensuring
+        // correct execution of the `javac` task.
         options.encoding = 'UTF-8'
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+
+        // Configure Error Prone:
+        // 1. Exclude generated sources from being analyzed by Error Prone.
+        // 2. Turn the check off until Error Prone can handle `@Nested` JUnit classes.
+        //    See issue: https://github.com/google/error-prone/issues/956
+        // 3. Turn off checks which report unused methods and unused method parameters.
+        //    See issue: https://github.com/SpineEventEngine/config/issues/61
+        //
+        // For more config details see:
+        //    https://github.com/tbroyer/gradle-errorprone-plugin/tree/master#usage
+
+        options.errorprone.errorproneArgs.addAll(
+                '-XepExcludedPaths:.*/generated/.*',
+                '-Xep:ClassCanBeStatic:OFF',
+                '-Xep:UnusedMethod:OFF',
+                '-Xep:UnusedVariable:OFF',
+                '-Xep:CheckReturnValue:OFF')
     }
 }

--- a/server/src/test/java/io/spine/examples/blog/server/BlogServerTest.java
+++ b/server/src/test/java/io/spine/examples/blog/server/BlogServerTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Abstract base for integration tests.
  */
 @DisplayName("BlogServer")
-public abstract class BlogServerTest {
+abstract class BlogServerTest {
 
     private Server server;
     private TestClient client;
@@ -69,7 +69,7 @@ public abstract class BlogServerTest {
         server.shutdownAndWait();
     }
 
-    protected final void send(CommandMessage command) {
+    final void send(CommandMessage command) {
         client.post(command);
     }
 


### PR DESCRIPTION
This PR:
  * Bumps `boostrap` -> `0.15.6`
  *  Consolidates Java compile configuration.
  * Adds `runtime` dependency on gRPC Netty. The dependency was transitive, and was removed from `core-java` recently.