### PR TITLE
Update to Spine `1.2.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.1.4' apply false
+    id 'io.spine.tools.gradle.bootstrap' version '1.2.0' apply false
     id 'net.ltgt.errorprone' version '1.1.1' apply false
 }
 

--- a/server/src/test/java/io/spine/examples/blog/server/BlogServerTest.java
+++ b/server/src/test/java/io/spine/examples/blog/server/BlogServerTest.java
@@ -73,8 +73,8 @@ abstract class BlogServerTest {
         client.post(command);
     }
 
-    final QueryResponse queryAll(Class<? extends EntityState> messageType) {
-        return client.queryAll(messageType);
+    final QueryResponse queryAll(Class<? extends EntityState> stateType) {
+        return client.queryAll(stateType);
     }
 
     static CreateBlog createBlog(BlogId id, String name) {

--- a/server/src/test/java/io/spine/examples/blog/server/BlogServerTest.java
+++ b/server/src/test/java/io/spine/examples/blog/server/BlogServerTest.java
@@ -20,8 +20,8 @@
 
 package io.spine.examples.blog.server;
 
-import com.google.protobuf.Message;
 import io.spine.base.CommandMessage;
+import io.spine.base.EntityState;
 import io.spine.client.QueryResponse;
 import io.spine.examples.blog.BlogId;
 import io.spine.examples.blog.PostId;
@@ -73,7 +73,7 @@ abstract class BlogServerTest {
         client.post(command);
     }
 
-    final QueryResponse queryAll(Class<? extends Message> messageType) {
+    final QueryResponse queryAll(Class<? extends EntityState> messageType) {
         return client.queryAll(messageType);
     }
 

--- a/version.gradle
+++ b/version.gradle
@@ -24,7 +24,7 @@ final def versions = [
         errorProneJavac  : "9+181-r4173-1", // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
         guava            : "28.1-jre",
         checkerFramework : "2.11.1",
-        netty            : "1.23.0",
+        netty            : "1.24.1",
         pmd              : "6.16.0",
         junit            : "5.5.2"
 ]


### PR DESCRIPTION
This PR updates the example to Spine of version `1.2.0`.

It also bumps some of the dependencies to match what's used in Spine `1.2.0`.